### PR TITLE
Remove previous config

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -86,7 +86,5 @@ function purdue_blocks_cgb_block_assets() { // phpcs:ignore
 	);
 }
 
-add_filter( 'block_categories', 'purdue_blocks_block_categories', 1, 2 );
-
 // Hook: Block assets.
 add_action( 'init', 'purdue_blocks_cgb_block_assets' );


### PR DESCRIPTION
Just realized there is one line of registering the block in init.php that I forgot to remove. This line breaks the core gutenberg blocks. Please merge at your earliest convenience. Thanks!