### PR TITLE
Feat/e2e proofpoint

### DIFF
--- a/src/proofpoint/__snapshots__/block.spec.js.snap
+++ b/src/proofpoint/__snapshots__/block.spec.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`🔬 Proofpoint Block Block should be available. 1`] = `
+"<!-- wp:purdue-blocks/title-nav -->
+<section class=\\"section pu-title-nav \\"><h2 class=\\"pu-title-nav__title\\"></h2><ul class=\\"pu-title-nav__menu\\"><!-- wp:purdue-blocks/title-nav-link -->
+<li class=\\"\\"></li>
+<!-- /wp:purdue-blocks/title-nav-link --></ul></section>
+<!-- /wp:purdue-blocks/title-nav -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Block Editor Fields 🔬 Proofpoint CTA fields CTA text field updates output correctly 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"ctaText\\":\\"CTA text\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Block Editor Fields 🔬 Proofpoint CTA fields CTA url field updates output correctly 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"ctaUrl\\":\\"https://www.purdue.edu\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Block Editor Fields 🔬 Proofpoint body text fields Content Text field updates output correctly 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"content\\":\\"Content text test.\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"><p class=\\"pu-proofpoint__content pu-proofpoint__content-narrow\\">Content text test.</p></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Block Editor Fields 🔬 Proofpoint body text fields Highlighted Text field updates output correctly 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"highlighted\\":\\"Highlighted text test.\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"><p class=\\"pu-proofpoint__highlighted pu-proofpoint__highlighted-narrow\\">Highlighted text test.</p></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Block Editor Fields 🔬 Proofpoint body text fields Proofpoint source field updates output correctly 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"source\\":\\"Proofpoint source test.\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"><p class=\\"pu-proofpoint__source\\">Proofpoint source test.</p></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Background color controls Add border checkbox correctly adds borders 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"color\\":\\"white\\",\\"border\\":true} -->
+<div class=\\"pu-proofpoint pu-proofpoint__white pu-proofpoint__border\\"><div class=\\"container\\"></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Background color controls White background option reveals add border checkbox 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"color\\":\\"white\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__white\\"><div class=\\"container\\"></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Text Style Settings Content text style radio controls 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"contentfontStyle\\":\\"wide\\",\\"content\\":\\"Content text test.\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"><p class=\\"pu-proofpoint__content pu-proofpoint__content-wide\\">Content text test.</p></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Text Style Settings Content text style radio controls 2`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"content\\":\\"Content text test.\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"><p class=\\"pu-proofpoint__content pu-proofpoint__content-narrow\\">Content text test.</p></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Text Style Settings Highlighted text style radio controls 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"highlighted\\":\\"Highlighted text test.\\",\\"headerfontStyle\\":\\"wide\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"><p class=\\"pu-proofpoint__highlighted pu-proofpoint__highlighted-wide\\">Highlighted text test.</p></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Text Style Settings Highlighted text style radio controls 2`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"highlighted\\":\\"Highlighted text test.\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__black\\"><div class=\\"container\\"><p class=\\"pu-proofpoint__highlighted pu-proofpoint__highlighted-narrow\\">Highlighted text test.</p></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;

--- a/src/proofpoint/__snapshots__/block.spec.js.snap
+++ b/src/proofpoint/__snapshots__/block.spec.js.snap
@@ -44,6 +44,18 @@ exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Background color co
 <!-- /wp:purdue-blocks/proofpoint -->"
 `;
 
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Background color controls Button color on white background updates output correctly 1`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"color\\":\\"white\\",\\"buttonColor\\":\\"white\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__white\\"><div class=\\"container\\"></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
+exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Background color controls Button color on white background updates output correctly 2`] = `
+"<!-- wp:purdue-blocks/proofpoint {\\"color\\":\\"white\\"} -->
+<div class=\\"pu-proofpoint pu-proofpoint__white\\"><div class=\\"container\\"></div></div>
+<!-- /wp:purdue-blocks/proofpoint -->"
+`;
+
 exports[`🔬 Proofpoint Block 🔬 Side Panel Settings 🔬 Background color controls White background option reveals add border checkbox 1`] = `
 "<!-- wp:purdue-blocks/proofpoint {\\"color\\":\\"white\\"} -->
 <div class=\\"pu-proofpoint pu-proofpoint__white\\"><div class=\\"container\\"></div></div>

--- a/src/proofpoint/block.spec.js
+++ b/src/proofpoint/block.spec.js
@@ -127,6 +127,24 @@ describe( '🔬 Proofpoint Block', () => {
                 expect( editedContent.includes(`"border":true`)).toBe(true)
                 expect( await getEditedPostContent() ).toMatchSnapshot()
             })
+
+            test('Button color on white background updates output correctly', async () => {
+                await blockStartup(block)
+
+                await clickRadio('Background Color', 'white')
+                await clickRadio('Button Color', 'white')
+
+                let editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"buttonColor":"white"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+
+
+                await clickRadio('Button Color', 'black')
+
+                editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"buttonColor":"white"`)).toBe(false)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
         })
 
         describe('🔬 Text Style Settings', () => {

--- a/src/proofpoint/block.spec.js
+++ b/src/proofpoint/block.spec.js
@@ -1,0 +1,180 @@
+// title-nav test
+jest.setTimeout(30000)
+import {
+    createNewPost,
+    enablePageDialogAccept,
+    getEditedPostContent,
+    insertBlock,
+} from '@wordpress/e2e-test-utils';
+
+import {
+    clickElementByText,
+    blockStartup,
+    updateRangeInput,
+    clickCheckbox,
+    clickRadio,
+    openSidebarPanelWithTitle
+} from '../test-helpers'
+
+const block = {blockTitle: 'Proof Point', blockName: 'purdue-blocks/proofpoint'}
+
+describe( '🔬 Proofpoint Block', () => {
+    beforeAll( async () => {
+        await enablePageDialogAccept();
+    } );
+    beforeEach( async () => {
+        await createNewPost();
+    } );
+
+    test( 'Block should be available.', async () => {
+        await insertBlock( 'Titled Navigation' )
+
+
+        // tests that the block is properly inserted and matches the existing snapshot
+        expect(await page.$('[data-type="purdue-blocks/title-nav"]')).not.toBeNull()
+        expect( await getEditedPostContent() ).toMatchSnapshot()
+    } )
+
+    describe('🔬 Block Editor Fields', () => {
+        describe('🔬 Proofpoint body text fields', () => {
+            test('Highlighted Text field updates output correctly', async () => {
+                await blockStartup(block)
+
+                const typeString = "Highlighted text test."
+    
+                await page.focus('input[placeholder="Highlighted Text..."]')
+                await page.keyboard.type(typeString, {delay: 10})
+    
+                const editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"highlighted":"${typeString}"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+            test('Content Text field updates output correctly', async () => {
+                await blockStartup(block)
+
+                const typeString = "Content text test."
+    
+                await page.focus('input[placeholder="Content Text..."]')
+                await page.keyboard.type(typeString, {delay: 10})
+    
+                const editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"content":"${typeString}"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+            test('Proofpoint source field updates output correctly', async () => {
+                await blockStartup(block)
+
+                const typeString = "Proofpoint source test."
+    
+                await page.focus('input[placeholder="Source of Text..."]')
+                await page.keyboard.type(typeString, {delay: 10})
+    
+                const editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"source":"${typeString}"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+        })
+
+        describe('🔬 Proofpoint CTA fields', () => {
+            test('CTA text field updates output correctly', async () => {
+                await blockStartup(block)
+
+                const typeString = "CTA text"
+    
+                await page.focus('input[placeholder="CTA Text..."]')
+                await page.keyboard.type(typeString, {delay: 10})
+    
+                const editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"ctaText":"${typeString}"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+            test('CTA url field updates output correctly', async () => {
+                await blockStartup(block)
+
+                const typeString = "https://www.purdue.edu"
+    
+                await page.focus('input[placeholder="CTA URL..."]')
+                await page.keyboard.type(typeString, {delay: 10})
+    
+                const editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"ctaUrl":"${typeString}"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+        })        
+    })
+
+    describe('🔬 Side Panel Settings', () => {
+        describe('🔬 Background color controls', () => {
+            test('White background option reveals add border checkbox', async () => {
+                await blockStartup(block)
+
+                await clickRadio('Background Color', 'white')
+
+                const [borderCheckbox] = await page.$x( `//label[@class="components-checkbox-control__label"][contains(text(),"Add border?")]` )
+
+                expect( borderCheckbox ).not.toBeNull()
+                expect( borderCheckbox ).not.toBe(undefined)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+
+            test('Add border checkbox correctly adds borders', async () => {
+                await blockStartup(block)
+
+                await clickRadio('Background Color', 'white')
+                await clickCheckbox('Add border?')
+                
+                const editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"border":true`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+        })
+
+        describe('🔬 Text Style Settings', () => {
+            test('Highlighted text style radio controls', async () => {
+                await blockStartup(block)
+
+                // type in some content so that the p el is added to output to test text style setting
+                const typeString = "Highlighted text test."
+                await page.focus('input[placeholder="Highlighted Text..."]')
+                await page.keyboard.type(typeString, {delay: 10})
+
+                const [wideControl] = await page.$x( `//div[@class="components-radio-control__option"][../label='Highlighted Text Style']//input[@value='wide']` )
+                await wideControl.click()
+                
+                let editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"headerfontStyle":"wide"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+
+                // then test that it swaps back correctly
+                const [narrowControl] = await page.$x( `//div[@class="components-radio-control__option"][../label='Highlighted Text Style']//input[@value='narrow']` )
+                await narrowControl.click()
+                
+                editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"headerfontStyle":"wide"`)).toBe(false)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+
+            test('Content text style radio controls', async () => {
+                await blockStartup(block)
+
+                // type in some content so that the p el is added to output to test text style setting
+                const typeString = "Content text test."
+                await page.focus('input[placeholder="Content Text..."]')
+                await page.keyboard.type(typeString, {delay: 10})
+
+                await clickRadio('Content Text Style', 'wide')
+                
+                let editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"contentfontStyle":"wide"`)).toBe(true)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+
+                // then test that it swaps back correctly
+                await clickRadio('Content Text Style', 'narrow')
+                
+                editedContent = await getEditedPostContent()
+                expect( editedContent.includes(`"contentfontStyle":"wide"`)).toBe(false)
+                expect( await getEditedPostContent() ).toMatchSnapshot()
+            })
+        })
+    })
+})

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -32,6 +32,11 @@ export const clickCheckbox = async (label) => {
     await selectEl.click()
 }
 
+export const clickRadio = async (labelText, value) => {
+    const [selectEl] = await page.$x( `//div[@class="components-radio-control__option"][../label='${labelText}']//input[@value='${value}']` )
+    await selectEl.click()
+}
+
 // Used when panel bodies on the side bar may be closed by default to open them so settings can be accessed
 export const openSidebarPanelWithTitle = async ( title ) => {
     // Check if sidebar panel exists


### PR DESCRIPTION
- Add tests for the proofpoint block
- Add new helper to click radio buttons, `async clickRadio(labelText, value)`
  - labelText is the label for the radio group
  - value is the HTML attribute on the button you wish to click